### PR TITLE
Add accesskey attributes

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,11 +37,11 @@
       <div class='py2' id='viz'></div>
       <form class='right-align'>
         <label class='inline-block'>
-          <input type='radio' name='party' value='D' checked>
+          <input type='radio' name='party' value='D' accesskey='d' checked>
           <span class='choice dem'></span>
         </label>
         <label class='inline-block'>
-          <input type='radio' name='party' value='R'>
+          <input type='radio' name='party' value='R' accesskey='r'>
           <span class='choice gop'></span>
         </label>
       </form>


### PR DESCRIPTION
This adds [accesskey attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/accesskey) to the party radio buttons so that you can switch parties with the keyboard. In Chrome on Mac you can see this at work with <kbd>control</kbd> + <kbd>alt</kbd> + (<kbd>d</kbd> | <kbd>r</kbd>).
